### PR TITLE
Fix incorrect init sharing global name

### DIFF
--- a/apps/docs/src/en/modules/ROOT/pages/versioned-shared-modules.adoc
+++ b/apps/docs/src/en/modules/ROOT/pages/versioned-shared-modules.adoc
@@ -258,7 +258,7 @@ Here is a sample code snippet on how to use a container dynamically:
 [source, javascript]
 ----
 // Initializes the share scope. This fills it with known provided modules from this build and all remotes
-await __webpack_initialize_sharing__("default");
+await __webpack_init_sharing__("default");
 const container = window.someContainer; // or get the container somewhere else
 // Initialize the container, it may provide shared modules
 await container.init(__webpack_share_scopes__.default);


### PR DESCRIPTION
It seems that the global name should be `__webpack_init_sharing__ ` instead of `__webpack_initialize_sharing__ `

Ref: https://webpack.js.org/concepts/module-federation/#dynamic-remote-containers